### PR TITLE
[Enhancement] Output an error for the user when a registry does not exist in clearblade

### DIFF
--- a/devices.go
+++ b/devices.go
@@ -11,8 +11,6 @@ import (
 	"log"
 	"math"
 	"net/http"
-	"net/url"
-	"os"
 
 	gcpiotcore "cloud.google.com/go/iot/apiv1"
 	"golang.org/x/exp/maps"
@@ -39,50 +37,6 @@ var fields = &fieldmaskpb.FieldMask{
 		"log_level",
 		"metadata",
 		"gateway_config"},
-}
-
-func registryExistsInClearBlade(ctx context.Context, registryName string) bool {
-	base, err := url.Parse("https://iot.clearblade.com/api/v/4/webhook/execute/" + Args.systemKey + "/cloudiot")
-	val, _ := getAbsPath(Args.serviceAccountFile)
-	parent := "projects/" + getProjectID(val) + "/locations/" + Args.gcpRegistryRegion + "/registries/" + Args.registryName
-	//Query params
-	params := url.Values{}
-	params.Add("parent", parent)
-	base.RawQuery = params.Encode()
-	req, err := http.NewRequest("GET", base.String(), nil)
-	req.Header.Set("Clearblade-UserToken", Args.token)
-
-	if err != nil {
-		log.Print(err)
-		os.Exit(1)
-		//return err.Error()
-	}
-
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		log.Fatalln(err)
-	}
-
-	var data cbRegistries
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		fmt.Println("Error while while requesting registries from clearblade", err)
-		os.Exit(1)
-	}
-	err2 := json.Unmarshal(body, &data)
-	if err2 != nil {
-		fmt.Println("Error while parsing json payload from clearblade", err2)
-		os.Exit(1)
-	}
-	var exists = false
-	for _, registry := range data.DeviceRegistries {
-		if registry.Id == registryName {
-			exists = true
-			break
-		}
-	}
-	return exists
 }
 
 func fetchDevicesFromGoogleIotCore(ctx context.Context, gcpClient *gcpiotcore.DeviceManagerClient) ([]*gcpiotpb.Device, map[string]interface{}) {

--- a/devices.go
+++ b/devices.go
@@ -2,20 +2,23 @@ package main
 
 import (
 	"bytes"
-	gcpiotcore "cloud.google.com/go/iot/apiv1"
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"golang.org/x/exp/maps"
-	"google.golang.org/api/iterator"
-	gcpiotpb "google.golang.org/genproto/googleapis/cloud/iot/v1"
-	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"io/ioutil"
 	"log"
 	"math"
 	"net/http"
+	"net/url"
+	"os"
+
+	gcpiotcore "cloud.google.com/go/iot/apiv1"
+	"golang.org/x/exp/maps"
+	"google.golang.org/api/iterator"
+	gcpiotpb "google.golang.org/genproto/googleapis/cloud/iot/v1"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
 var fields = &fieldmaskpb.FieldMask{
@@ -36,6 +39,50 @@ var fields = &fieldmaskpb.FieldMask{
 		"log_level",
 		"metadata",
 		"gateway_config"},
+}
+
+func registryExistsInClearBlade(ctx context.Context, registryName string) bool {
+	base, err := url.Parse("https://iot.clearblade.com/api/v/4/webhook/execute/" + Args.systemKey + "/cloudiot")
+	val, _ := getAbsPath(Args.serviceAccountFile)
+	parent := "projects/" + getProjectID(val) + "/locations/" + Args.gcpRegistryRegion + "/registries/" + Args.registryName
+	//Query params
+	params := url.Values{}
+	params.Add("parent", parent)
+	base.RawQuery = params.Encode()
+	req, err := http.NewRequest("GET", base.String(), nil)
+	req.Header.Set("Clearblade-UserToken", Args.token)
+
+	if err != nil {
+		log.Print(err)
+		os.Exit(1)
+		//return err.Error()
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	var data cbRegistries
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println("Error while while requesting registries from clearblade", err)
+		os.Exit(1)
+	}
+	err2 := json.Unmarshal(body, &data)
+	if err2 != nil {
+		fmt.Println("Error while parsing json payload from clearblade", err2)
+		os.Exit(1)
+	}
+	var exists = false
+	for _, registry := range data.DeviceRegistries {
+		if registry.Id == registryName {
+			exists = true
+			break
+		}
+	}
+	return exists
 }
 
 func fetchDevicesFromGoogleIotCore(ctx context.Context, gcpClient *gcpiotcore.DeviceManagerClient) ([]*gcpiotpb.Device, map[string]interface{}) {

--- a/main.go
+++ b/main.go
@@ -101,10 +101,12 @@ func main() {
 
 	exists := registryExistsInClearBlade(Args.registryName)
 	if exists {
-		fmt.Print(Args.registryName, " is already in Clearblade project.")
+		log.Println(Args.registryName, " is already in Clearblade project.")
 	} else {
-		fmt.Print(Args.registryName, " is not present in the Clearblade project"+
-			"Creating the registry in clearblade ...")
+		log.Fatalln(Args.registryName, " registry is not present in the Clearblade project. "+
+			"Please create the registry in clearblade then retry")
+		os.Exit(1)
+		//TODO: next, create the registry through an API call
 	}
 	// Fetch devices from the given registry
 	devices, deviceConfigs := fetchDevicesFromGoogleIotCore(ctx, gcpClient)

--- a/main.go
+++ b/main.go
@@ -99,11 +99,12 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	exists := registryExistsInClearBlade(ctx, Args.registryName)
+	exists := registryExistsInClearBlade(Args.registryName)
 	if exists {
-		fmt.Print(Args.registryName, " is present in the array.")
+		fmt.Print(Args.registryName, " is already in Clearblade project.")
 	} else {
-		fmt.Print(Args.registryName, " is not present in the array. creating the registry in clearblade ...")
+		fmt.Print(Args.registryName, " is not present in the Clearblade project"+
+			"Creating the registry in clearblade ...")
 	}
 	// Fetch devices from the given registry
 	devices, deviceConfigs := fetchDevicesFromGoogleIotCore(ctx, gcpClient)

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	gcpiotcore "cloud.google.com/go/iot/apiv1"
 	"context"
 	"errors"
 	"flag"
@@ -9,6 +8,8 @@ import (
 	"log"
 	"os"
 	"runtime"
+
+	gcpiotcore "cloud.google.com/go/iot/apiv1"
 )
 
 var (
@@ -29,7 +30,7 @@ type DeviceMigratorArgs struct {
 	token            string
 	systemKey        string
 	cbRegistryRegion string
-
+	platformURLREST  string
 	// GCP IoT Core specific flags
 	serviceAccountFile string
 	registryName       string
@@ -98,6 +99,12 @@ func main() {
 		log.Fatalln(err)
 	}
 
+	exists := registryExistsInClearBlade(ctx, Args.registryName)
+	if exists {
+		fmt.Print(Args.registryName, " is present in the array.")
+	} else {
+		fmt.Print(Args.registryName, " is not present in the array. creating the registry in clearblade ...")
+	}
 	// Fetch devices from the given registry
 	devices, deviceConfigs := fetchDevicesFromGoogleIotCore(ctx, gcpClient)
 

--- a/registries.go
+++ b/registries.go
@@ -1,0 +1,66 @@
+// Handles registries operations
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+)
+
+// returns true if a registryName exists in the Clearblade project and region.
+func registryExistsInClearBlade(registryName string) bool {
+
+	err, resp := cbListRegistries()
+
+	var data cbRegistries
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println("Error while while requesting registries from clearblade", err)
+		os.Exit(1)
+	}
+	err2 := json.Unmarshal(body, &data)
+	if err2 != nil {
+		fmt.Println("Error while parsing json payload from clearblade", err2)
+		os.Exit(1)
+	}
+	var exists = false
+	for _, registry := range data.DeviceRegistries {
+		if registry.Id == registryName {
+			exists = true
+			break
+		}
+	}
+	return exists
+}
+
+// retrieves list of registries in clearblade by systemKey, gcpRegistryRegion, and projectId.
+// TODO: this is temporary until the GetRegistry is fixed:
+// https://github.com/ClearBlade/clearblade-iot-core-migration/issues/4
+func cbListRegistries() (error, *http.Response) {
+	base, err := url.Parse("https://iot.clearblade.com/api/v/4/webhook/execute/" + Args.systemKey + "/cloudiot")
+	val, _ := getAbsPath(Args.serviceAccountFile)
+	parent := "projects/" + getProjectID(val) + "/locations/" + Args.gcpRegistryRegion
+	//Query params
+	params := url.Values{}
+	params.Add("parent", parent)
+	base.RawQuery = params.Encode()
+	req, err := http.NewRequest("GET", base.String(), nil)
+	req.Header.Set("Clearblade-UserToken", Args.token)
+
+	if err != nil {
+		log.Print(err)
+		os.Exit(1)
+		//return err.Error()
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	return err, resp
+}

--- a/types.go
+++ b/types.go
@@ -57,3 +57,20 @@ type GatewayConfig struct {
 	LastAccessedGatewayId   string `json:"lastAccessedGatewayId,omitempty"`
 	LastAccessedGatewayTime string `json:"lastAccessedGatewayTime,omitempty"`
 }
+
+type cbRegistries struct {
+	//DeviceRegistries []cbRegistry `json:"deviceRegistries"`
+	DeviceRegistries []cbRegistry `json:"deviceRegistries"`
+	NextPageToken    int          `json:"nextPageToken"`
+}
+
+type cbRegistry struct {
+	Id string `json:"id"`
+	//Name string `json:"name"`
+	//Credentials              any    `json:"credentials"`
+	//EventNotificationConfigs any    `json:"eventNotificationConfigs"`
+	//StateNotificationConfig  any    `json:"stateNotificationConfig"`
+	//HttpConfig               any    `json:"httpConfig"`
+	//MqttConfig               any    `json:"mqttConfig"`
+	//LogLevel                 any    `json:"logLevel"`
+}


### PR DESCRIPTION
When migrating a registry from cloud iot core to clearblade, the registry needs to exist in clearblade.
This pull request outputs a message for the user to create the registry manually and retry.

The following PR will create the registry for the user in Clearblade if not already there.

ps: my first code in Go, feedback is welcome :)